### PR TITLE
With xeno>=7.6.0, components are automatically expanded.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-xeno = "*"
+xeno = ">=7.6.0"
 
 [dev-packages]
 

--- a/build.py
+++ b/build.py
@@ -43,7 +43,7 @@ def objects(sources, headers):
 # --------------------------------------------------------------------
 @task(default=True)
 def executable(objects):
-    return compile(objects.components(), target="hasher", env=LINK_ENV)
+    return compile(objects, target="hasher", env=LINK_ENV)
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Be sure to `pipenv --rm` first to get rid of the old version!